### PR TITLE
[BUGFIX] Wrong HTML structure for internal video files

### DIFF
--- a/Resources/Private/Extensions/fluid_styled_content/Partials/Media/Type/Video.html
+++ b/Resources/Private/Extensions/fluid_styled_content/Partials/Media/Type/Video.html
@@ -2,10 +2,10 @@
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
 <f:variable name="previewImage" value="{jw:videoPreviewImage(fileReference: '{file}')}" />
 <f:variable name="playerHtml" value="{f:render(partial: 'Media/Rendering/Video', arguments: '{file: file, dimensions: dimensions, settings: settings}')}" />
-<f:if condition="{previewImage}">
-	<f:then>
-		<figure class="video">
-			<div class="video-embed">
+<figure class="video">
+	<div class="video-embed">
+		<f:if condition="{previewImage}">
+			<f:then>
 				<a href="#play" class="video-shariff-play" data-video="{playerHtml -> jw:video()}">
 					<f:image src="{previewImage}" width="{dimensions.width}" height="{dimensions.height}"/>
 					<span class="video-shariff-preview-overlay"></span>
@@ -14,17 +14,17 @@
 						<span class="video-shariff-preview-text"><f:translate key="preview.text" extensionName="videoShariff" /></span>
 					</div>
 				</a>
-			</div>
-			<f:if condition="{file.description}">
-				<figcaption class="video-caption">
-					{file.description}
-				</figcaption>
-			</f:if>
-		</figure>
-	</f:then>
-	<f:else>
-		<f:comment>Render player directly if no helper is available (for local videos)</f:comment>
-		<f:format.raw>{playerHtml}</f:format.raw>
-	</f:else>
-</f:if>
+			</f:then>
+			<f:else>
+				<f:comment>Render player directly if no helper is available (for local videos)</f:comment>
+				<f:format.raw>{playerHtml}</f:format.raw>
+			</f:else>
+		</f:if>
+	</div>
+	<f:if condition="{file.description}">
+		<figcaption class="video-caption">
+			{file.description}
+		</figcaption>
+	</f:if>
+</figure>
 </html>


### PR DESCRIPTION
The HTML structure for internal videos was not correct. Two surrounding elements were missing, which are necessary for example if you want to use CSS responsive videos.