### PR TITLE
Update VideoShariff.js

### DIFF
--- a/Resources/Public/JavaScript/VideoShariff.js
+++ b/Resources/Public/JavaScript/VideoShariff.js
@@ -1,13 +1,17 @@
-function replaceVideo(event) {
-    let previewLink = event.target;
+(function () {
 
-    while (previewLink.className !== 'video-shariff-play') {
-        previewLink = previewLink.parentElement;
+    function replaceVideo(event) {
+        let previewLink = event.target;
+
+        while (previewLink.className !== 'video-shariff-play') {
+            previewLink = previewLink.parentElement;
+        }
+        previewLink.outerHTML = JSON.parse(previewLink.dataset.video);
     }
-    previewLink.outerHTML = JSON.parse(previewLink.dataset.video);
-}
 
-let videos = document.getElementsByClassName('video-shariff-play'), i = 0;
-for (i; i < videos.length; i++) {
-    videos[i].onclick = function(event){event.preventDefault(); replaceVideo(event);};
-}
+    let videos = document.getElementsByClassName('video-shariff-play'), i = 0;
+    for (i; i < videos.length; i++) {
+        videos[i].onclick = function(event){event.preventDefault(); replaceVideo(event);};
+    }
+
+})();


### PR DESCRIPTION
Wrap javascript to limit the scope of the variables.
The old version leads to errors in combination with extension go_maps_ext because of the general scope of "let i=0;"