### PR TITLE
[BUGFIX] Fix path to default thumbnail

### DIFF
--- a/Classes/ViewHelpers/VideoPreviewImageViewHelper.php
+++ b/Classes/ViewHelpers/VideoPreviewImageViewHelper.php
@@ -18,6 +18,7 @@ use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Resource\FileReference;
 use TYPO3\CMS\Core\Resource\OnlineMedia\Helpers\OnlineMediaHelperInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\PathUtility;
 use TYPO3\CMS\Extbase\Domain\Model\FileReference as ExtbaseFileReference;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -94,6 +95,6 @@ class VideoPreviewImageViewHelper extends AbstractViewHelper
     {
         $filename = self::getTypoScriptSetup()['lib.']['video_shariff.']['defaultThumbnail'] ?? '';
 
-        return $filename ? GeneralUtility::getFileAbsFileName($filename) : '';
+        return $filename ? PathUtility::getPublicResourceWebPath($filename) : '';
     }
 }


### PR DESCRIPTION
In Composer installations `GeneralUtility::getFileAbsFileName` returns an absolute path to the file within the `vendor` directory.

This is unsuitable here, as a public path is assumed internally in `ResourceFactory::retrieveFileOrFolderObject` when checking whether the path is a file or folder.

For this reason, `PathUtility::getPublicResourceWebPath` is the more suitable choice here to prevent "Folder does not exist" error messages in the `ImageViewHelper` context using the resulting path.