### PR TITLE
[BUGFIX] Prevent TypeError when returning public URL

### DIFF
--- a/Classes/ViewHelpers/VideoPublicUrlViewHelper.php
+++ b/Classes/ViewHelpers/VideoPublicUrlViewHelper.php
@@ -61,7 +61,7 @@ class VideoPublicUrlViewHelper extends AbstractViewHelper
         $file = $fileReference->getOriginalFile();
         $helper = self::getOnlineMediaHelper($file);
         if ($helper instanceof OnlineMediaHelperInterface) {
-            $publicUrl = $helper->getPublicUrl($file);
+            $publicUrl = $helper->getPublicUrl($file) ?? '';
         }
 
         return $publicUrl;


### PR DESCRIPTION
This commit fixes a TypeError in `VideoPublicUrlViewHelper::renderStatic()`. The `OnlineMediaHelperInterface::getPublicUrl()` method can return string or null.

see https://github.com/TYPO3/typo3/blob/v11.5.40/typo3/sysext/core/Classes/Resource/OnlineMedia/Helpers/OnlineMediaHelperInterface.php#L50-L59
see https://github.com/TYPO3/typo3/blob/v12.4.21/typo3/sysext/core/Classes/Resource/OnlineMedia/Helpers/OnlineMediaHelperInterface.php#L48-L56